### PR TITLE
Fix: Issue with phenotypist saved state 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8100,9 +8100,9 @@
       }
     },
     "iobio-phenotype-extractor-vue": {
-      "version": "0.1.63",
-      "resolved": "https://registry.npmjs.org/iobio-phenotype-extractor-vue/-/iobio-phenotype-extractor-vue-0.1.63.tgz",
-      "integrity": "sha512-Qng1FmMifeC8WyZElGQ5T5m7FII2PGAnXZTwQ7P41wWZJ+2C+vlga/l5olFBji02RuWM7iLQz0wtaVo5thY5SA==",
+      "version": "0.1.64",
+      "resolved": "https://registry.npmjs.org/iobio-phenotype-extractor-vue/-/iobio-phenotype-extractor-vue-0.1.64.tgz",
+      "integrity": "sha512-+7NhTKqPYKqmO4AmNusK17N71lI03TNiBSBe08RpVpiPJVdZsWELNgl16xi6x8Y3KsZW5tCiRCn/2JOL5hdQmA==",
       "requires": {
         "core-js": "^3.3.2",
         "d3": "^3.5.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8100,9 +8100,9 @@
       }
     },
     "iobio-phenotype-extractor-vue": {
-      "version": "0.1.64",
-      "resolved": "https://registry.npmjs.org/iobio-phenotype-extractor-vue/-/iobio-phenotype-extractor-vue-0.1.64.tgz",
-      "integrity": "sha512-+7NhTKqPYKqmO4AmNusK17N71lI03TNiBSBe08RpVpiPJVdZsWELNgl16xi6x8Y3KsZW5tCiRCn/2JOL5hdQmA==",
+      "version": "0.1.65",
+      "resolved": "https://registry.npmjs.org/iobio-phenotype-extractor-vue/-/iobio-phenotype-extractor-vue-0.1.65.tgz",
+      "integrity": "sha512-hdSJ9E2iQbOD9d0WspMUNF1p1o7N/VWbLFcmAJrjjTjt5WGkLdiY4NxBDH4fMAerO6jJbLSJtFxvEaZd9mxTAw==",
       "requires": {
         "core-js": "^3.3.2",
         "d3": "^3.5.17",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "debug": "^2.6.8",
     "express": "^4.15.3",
     "file-saver": "^2.0.2",
-    "iobio-phenotype-extractor-vue": "^0.1.64",
+    "iobio-phenotype-extractor-vue": "^0.1.65",
     "is-number": "^7.0.0",
     "jquery": "^3.4.1",
     "material-design-icons-iconfont": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "debug": "^2.6.8",
     "express": "^4.15.3",
     "file-saver": "^2.0.2",
-    "iobio-phenotype-extractor-vue": "^0.1.63",
+    "iobio-phenotype-extractor-vue": "^0.1.64",
     "is-number": "^7.0.0",
     "jquery": "^3.4.1",
     "material-design-icons-iconfont": "^5.0.1",

--- a/src/components/pages/ClinHome.vue
+++ b/src/components/pages/ClinHome.vue
@@ -27,7 +27,7 @@
 .v-btn
   letter-spacing: initial !important
 
-.theme--dark.v-toolbar.v-sheet 
+.theme--dark.v-toolbar.v-sheet
   background-color: $nav-color !important
 
 
@@ -1116,11 +1116,11 @@ export default {
       if (self.newWorkflow) {
         if (self.$refs.workflowRefNew) {
           self.$refs.workflowRefNew.refresh();
-        }          
+        }
       } else {
         if (self.$refs.workflowRef) {
           self.$refs.workflowRef.refresh();
-        }          
+        }
 
       }
 
@@ -1499,6 +1499,20 @@ export default {
       return self.promiseAutosaveAnalysis();
     },
 
+    promiseUpdateVennDiagramData: function(data) {
+      let self = this;
+      self.analysis.payload.VennDiagramData = data;
+      console.log("self.analysis.payload.VennDiagramData", self.analysis.payload.VennDiagramData)
+      self.analysis.payload.datetime_last_modified = self.getCurrentDateTime();
+      return self.promiseAutosaveAnalysis();
+    },
+
+    promiseUpdateGenesReport: function(genes) {
+      let self = this;
+      self.analysis.payload.genesReport = genes;
+      self.analysis.payload.datetime_last_modified = self.getCurrentDateTime();
+      return self.promiseAutosaveAnalysis();
+    },
 
     promiseUpdateAnalysis: function(analysis) {
       let self = this;
@@ -1698,11 +1712,12 @@ export default {
     summaryGenes(genes){
       this.summaryGeneList = genes;
       this.analysis.payload.genesReport = this.summaryGeneList;
+      this.promiseUpdateGenesReport(genes);
     },
 
     saveSearchedPhenotypes(phenotypes){
       this.analysis.payload.phenotypes = phenotypes;
-      this.promiseUpdateGenesData(this.analysis);
+      // this.promiseUpdateGenesData(this.analysis);
       this.promiseUpdatePhenotypes(phenotypes);
     },
 
@@ -1780,7 +1795,8 @@ export default {
       this.venn_diag_data = data;
     },
     VennDiagramData(obj){
-      this.analysis.payload.VennDiagramData = obj
+      this.analysis.payload.VennDiagramData = obj;
+      this.promiseUpdateVennDiagramData(obj);
     },
 
     updateReviewCaseBadges(badges){

--- a/src/components/pages/ClinHome.vue
+++ b/src/components/pages/ClinHome.vue
@@ -1502,7 +1502,6 @@ export default {
     promiseUpdateVennDiagramData: function(data) {
       let self = this;
       self.analysis.payload.VennDiagramData = data;
-      console.log("self.analysis.payload.VennDiagramData", self.analysis.payload.VennDiagramData)
       self.analysis.payload.datetime_last_modified = self.getCurrentDateTime();
       return self.promiseAutosaveAnalysis();
     },
@@ -1717,7 +1716,6 @@ export default {
 
     saveSearchedPhenotypes(phenotypes){
       this.analysis.payload.phenotypes = phenotypes;
-      // this.promiseUpdateGenesData(this.analysis);
       this.promiseUpdatePhenotypes(phenotypes);
     },
 


### PR DESCRIPTION
I had noticed the following issues in phenotypist when a saved analysis was launched 2nd time: 
1. Deleting a GTR term would delete all other GTR terms 
2. Venn Diagram state was not correctly shown when launched from a saved analysis. 

This Pull Request fixes the above issues. 