### PR TITLE
Finding page variants ordering and finding page badges 

### DIFF
--- a/src/components/pages/ClinHome.vue
+++ b/src/components/pages/ClinHome.vue
@@ -377,9 +377,9 @@ export default {
       variantsByInterpretationTemplate: [
        { key: 'sig',         display: 'significant',  abbrev: 'Significant', organizedVariants: []},
        { key: 'unknown-sig', display: 'unknown significance ', abbrev: 'Unknown Sig', organizedVariants: []},
+       { key: 'not-reviewed', display: 'Not Reviewed', abbrev: 'Not reviewed', organizedVariants: []},
        { key: 'poor-qual', display: 'poor quality', abbrev: 'Poor qual', organizedVariants: []},
        { key: 'not-sig', display: 'Not Significant', abbrev: 'Not sig', organizedVariants: []},
-       { key: 'not-reviewed', display: 'Not Reviewed', abbrev: 'Not reviewed', organizedVariants: []}
       ],
 
       variantsByInterpretation: [],
@@ -464,10 +464,10 @@ export default {
       interpretationMap: {
         'sig': 'Significant',
         'unknown-sig': 'Unknown significance',
+        'not-reviewed': 'Not reviewed',
         'not-sig': 'Not significant',
         'poor-qual': 'Poor quality',
         'reviewed': 'Reviewed',
-        'not-reviewed': 'Not reviewed'
       },
       reviewCaseBadges: null,
       generatingReport: false,
@@ -1165,6 +1165,14 @@ export default {
               let badgeLabels = [];
               let badgeCounts = [];
               let badgeClasses = [];
+              
+              //Add the count of variant which is not reviewed (but has comments) to unknown-sig
+              if(self.variantsByInterpretation.length && self.variantsByInterpretation[2].key ==  'not-reviewed' && self.variantsByInterpretation[1].key == 'unknown-sig'){
+                if(self.variantsByInterpretation[2].variantCount > 0){
+                  self.variantsByInterpretation[1].variantCount += self.variantsByInterpretation[2].variantCount; 
+                }
+              }
+              
               self.variantsByInterpretation.forEach(function(interpretation) {
                 if(interpretation.key == 'sig' || interpretation.key == 'unknown-sig' || interpretation.key == "poor-qual"){
                   if(interpretation.variantCount > 0){

--- a/src/components/pages/ClinHome.vue
+++ b/src/components/pages/ClinHome.vue
@@ -1646,7 +1646,7 @@ export default {
         theVariants.forEach(function(variant) {
           let isReviewed = (variant.notes && variant.notes.length > 0)
                     || (variant.interpretation != null
-                    && (variant.interpretation == "sig" || variant.interpretation == "unknown-sig" || variant.interpretation == "not-sig" || variant.interpretation == "poor-qual" || (variant.interpretation == "not-reviewed" && variant.notes.length>0)));
+                    && (variant.interpretation == "sig" || variant.interpretation == "unknown-sig" || (variant.interpretation == "not-sig" && variant.notes.length>0) || variant.interpretation == "poor-qual" || (variant.interpretation == "not-reviewed" && variant.notes.length>0)));
 
           if (isReviewed && filterName && filterName == 'reviewed') {
 

--- a/src/components/partials/findings/VariantInterpretationBadge.vue
+++ b/src/components/partials/findings/VariantInterpretationBadge.vue
@@ -1,5 +1,5 @@
 <template>
-
+  
   <div
   id="badge-interpretation"
   :class="{
@@ -13,8 +13,9 @@
     <v-icon class="interpretation unknown-sig" v-if="interpretation == 'unknown-sig'">help</v-icon>
     <v-icon class="interpretation not-sig" v-if="interpretation == 'not-sig'">thumb_down</v-icon>
     <v-icon class="interpretation poor-qual" v-if="interpretation == 'poor-qual'">trending_down</v-icon>
-    <v-icon class="interpretation not-reviewed" v-if="interpretation == 'not-reviewed'">visibility_off</v-icon>
-    <span  class="interpretation-label"> {{ intepretationDisplay }} </span>
+    <v-icon class="interpretation unknown-sig" v-if="interpretation == 'not-reviewed'">help</v-icon>
+    <span v-if="intepretationDisplay === 'Not reviewed'" class="interpretation-label"> Unknown significance </span>
+    <span v-else class="interpretation-label"> {{ intepretationDisplay }} </span>
 
   </div>
 
@@ -97,7 +98,7 @@ i.material-icons.interpretation
 
   &.not-reviewed
     i.material-icons
-      color: $not-reviewed-color !important
+      color: $unknown-significance-color !important
 
   &.sig
     i.material-icons


### PR DESCRIPTION
Variants in findings page are shown in the following order: 

-  Significant, Unknown significance, Poor quality, 
- If notes are added but no assertion is applied, assign Unknown signficance