### PR TITLE
HPO terms are cleared on edit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8105,9 +8105,9 @@
       }
     },
     "iobio-phenotype-extractor-vue": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/iobio-phenotype-extractor-vue/-/iobio-phenotype-extractor-vue-1.0.20.tgz",
-      "integrity": "sha512-wTXCTzEW2uhuQS0vsXhqRpSibg9khI3K9dAYpdcJM4j5H7sOlgDXoRvrcRADJDSXThN4EYHnMDOQbX5OIf3Edw==",
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/iobio-phenotype-extractor-vue/-/iobio-phenotype-extractor-vue-1.0.22.tgz",
+      "integrity": "sha512-oy8tMQCJOSX8TgFSBzHzjJi/gjfjqgvK8HLSg43KipLSc+MWtepxV7iuvjrE+TtwpEWR5WMRBMCNcRZhvBalwA==",
       "requires": {
         "core-js": "^3.3.2",
         "d3": "^3.5.17",
@@ -14607,9 +14607,9 @@
       "optional": true
     },
     "uiv": {
-      "version": "0.34.3",
-      "resolved": "https://registry.npmjs.org/uiv/-/uiv-0.34.3.tgz",
-      "integrity": "sha512-QX/CoqBXSoIzln2B8TSUpQin+eU+tVCtv3KWwWwGt7/cNnjC3UhHJm/HJSA48kI/XoOWAxh37Cb730xOk5ECbA==",
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/uiv/-/uiv-0.34.4.tgz",
+      "integrity": "sha512-J3Y53f/PcySbMpSEqkYwp2vtIIb+z3PQqvEqWdzD8RWrabFRxd1sd6iiRHx3cX5gzQtv79HtxR1tAk/xC4cSnw==",
       "requires": {
         "vue-functional-data-merge": "^2.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "express": "^4.15.3",
     "file-saver": "^2.0.2",
     "hooper": "^0.3.4",
-    "iobio-phenotype-extractor-vue": "^1.0.20",
+    "iobio-phenotype-extractor-vue": "^1.0.22",
     "is-number": "^7.0.0",
     "jquery": "^3.4.1",
     "material-design-icons-iconfont": "^5.0.1",


### PR DESCRIPTION
Selected HPO terms should be shown when the term selection modal is opened for re-selection. 

Do `npm install` to update the components package.
Test link: http://dev.clin.iobio.io/

Steps to check: 

- Go to demo data, Select Phenotypes and select terms for GTR, Phenolyzer and HPO.
- Data is analyzed and we get genes
- On Inputs, click Edit
- All the tools should show previously selected terms
- Review and Status portion should show selected terms.  



Earlier behavior: 

- Go to demo data, Select Phenotypes and select the first term for GTR, Phenolyzer and HPO.
- Data is analyzed and we get genes
- On Inputs, click Edit
- In GTR and Phenolyzer, the first term is still selected, but HPO is blank. So if I just click Next through the whole thing, I retain terms from GTR and Phenolyzer, but HPO is blank.
- In the Review portion, the HPO field is listed as "Not selected..."
- In the Status portion, the HPO term is back, and is retained in the gene list.

The HPO terms that were already selected should remain selected as they do for the other resources.

