### PR TITLE
update delete icons in select-phenotypes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8105,9 +8105,9 @@
       }
     },
     "iobio-phenotype-extractor-vue": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/iobio-phenotype-extractor-vue/-/iobio-phenotype-extractor-vue-1.0.24.tgz",
-      "integrity": "sha512-mdLm13y/8rvTswV0IFIvwfjwFWisNb/gA8CTGCztIJwRx8bhM6vrp+c3SWpFtQ54ASQYnt/sW5gBWqPW/DQ1ig==",
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/iobio-phenotype-extractor-vue/-/iobio-phenotype-extractor-vue-1.0.25.tgz",
+      "integrity": "sha512-NGu4qwnoD7daAGsszYaEd+SCGasKrkIyNzkJQqDgMu044tRkfzpbgTji0TfRyJBI+FZSPasasIWFK1zNC59RAw==",
       "requires": {
         "core-js": "^3.3.2",
         "d3": "^3.5.17",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "express": "^4.15.3",
     "file-saver": "^2.0.2",
     "hooper": "^0.3.4",
-    "iobio-phenotype-extractor-vue": "^1.0.24",
+    "iobio-phenotype-extractor-vue": "^1.0.25",
     "is-number": "^7.0.0",
     "jquery": "^3.4.1",
     "material-design-icons-iconfont": "^5.0.1",


### PR DESCRIPTION
This updates the delete (remove) icon in review terms dialog and in the terms panel in select phenotypes step. 
Earlier icon: 
<img width="260" alt="79080043-87637600-7cc7-11ea-986c-1acb22abee9d (1)" src="https://user-images.githubusercontent.com/16284713/79618467-f8879c80-80be-11ea-83b3-d3ee625b8ac4.png">

The delete icon as seen above should be replaced by the one seen in the genes table. 