### PR TITLE
update hpo data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8195,9 +8195,9 @@
       }
     },
     "iobio-phenotype-extractor-vue": {
-      "version": "1.0.30",
-      "resolved": "https://registry.npmjs.org/iobio-phenotype-extractor-vue/-/iobio-phenotype-extractor-vue-1.0.30.tgz",
-      "integrity": "sha512-ZK/v8ltsC+P5UzbbHcmtNO/DA0Dyb7QPtr2J/j2KWw14wZp6446z1LxGaPCUKAd3k8XgPQpM08iQy4vRNS9kaA==",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/iobio-phenotype-extractor-vue/-/iobio-phenotype-extractor-vue-1.0.32.tgz",
+      "integrity": "sha512-5SxVdHziEydHhAa/OGbO5vbBdPh4l8399K3B7SXfvCIirLPcrXDjKLgmlckMaBg76UNPCGx/O7aLbstgDrxBpA==",
       "requires": {
         "core-js": "^3.3.2",
         "d3": "^3.5.17",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "express": "^4.15.3",
     "file-saver": "^2.0.2",
     "hooper": "^0.3.4",
-    "iobio-phenotype-extractor-vue": "^1.0.30",
+    "iobio-phenotype-extractor-vue": "^1.0.32",
     "is-number": "^7.0.0",
     "jquery": "^3.4.1",
     "material-design-icons-iconfont": "^5.0.1",


### PR DESCRIPTION
To test: 
Select the demo note. Review the HPO terms and only select "Peripheral demyelination - [ HP:0011096 ]" to generate the gene list. 
It should show 47 genes. The earlier version had only 19 genes associated with this term. You can compare the results with stage.clin or prod version. 
You can also test it on dev.clin 
If testing locally do `npm install`. 