### PR TITLE
Fix hpo associations findings

### DIFF
--- a/src/components/partials/findings/VariantInspectRow.vue
+++ b/src/components/partials/findings/VariantInspectRow.vue
@@ -147,20 +147,18 @@ export default {
         margin-top: 0px
         margin-bottom: 0px
         margin-right: 0px
-        background: none
-        height: 16px
         .chip__content, .v-chip__content
-          padding: 0 0px
-          height: 15px
-          width: 34px
-          font-size: 12px
+          padding: 10px !important
+          height: 18px !important
+          width: 70px !important
+          font-size: 11px !important
           justify-content: center
           color: $text-color
-          border-radius: 28px
         &.high
           .chip__content, .v-chip__content
             background-color:  $danger-color
             color: white
+            border-radius: 16px
         
 
 

--- a/src/components/viz/findings/GeneAssociationsDialog.vue
+++ b/src/components/viz/findings/GeneAssociationsDialog.vue
@@ -25,6 +25,14 @@
 #gene-associations-dialog-divider
   margin-top: 10px !important
   margin-bottom: 5px !important
+  
+.phenotype-search-term
+  max-width: 200px
+  display: inline-block
+  vertical-align: top
+  line-height: 14px
+  padding-top: 5px  
+  overflow-wrap: normal
 </style>
 
 <template>
@@ -56,7 +64,7 @@
                         <v-chip color="white" class="high_gene_rank mr-1">
                           #{{ term.geneRanks[0].rank}}
                         </v-chip> 
-                        {{ term.searchTerm | to-firstCharacterUppercase }}
+                        <span class="phenotype-search-term">{{ term.searchTerm | to-firstCharacterUppercase }}</span>
                       </td>
                     </tr>
                   </tbody>
@@ -77,7 +85,7 @@
                         <v-chip color="white" class="high_gene_rank mr-1">
                           #{{ term.geneRanks[0].rank}}
                         </v-chip> 
-                        {{ term.searchTerm | to-firstCharacterUppercase }}
+                        <span class="phenotype-search-term">{{ term.searchTerm | to-firstCharacterUppercase }}</span>
                       </td>
                     </tr>
                   </tbody>

--- a/src/components/viz/findings/GeneAssociationsDialog.vue
+++ b/src/components/viz/findings/GeneAssociationsDialog.vue
@@ -5,7 +5,6 @@
   margin-top: 2px
   margin-bottom: 0px
   margin-right: 0px
-  background-color: white !important
   &.high_gene_rank
     .chip__content, .v-chip__content
       background-color:  $danger-color !important

--- a/src/components/viz/findings/GeneAssociationsDialog.vue
+++ b/src/components/viz/findings/GeneAssociationsDialog.vue
@@ -1,0 +1,196 @@
+<style lang="sass">
+@import ../../../assets/sass/variables
+.chip, .v-chip
+  vertical-align: top
+  margin-top: 2px
+  margin-bottom: 0px
+  margin-right: 0px
+  background-color: white !important
+  &.high_gene_rank
+    .chip__content, .v-chip__content
+      background-color:  $danger-color !important
+      color: white
+      padding: 6px
+      height: 18px
+      width: 40px
+      font-size: 12px
+      justify-content: center
+      border-radius: 16px
+
+.close-button
+  right: 10px !important
+  top: 15px !important
+  position: absolute !important
+  min-width: 40px !important
+
+#gene-associations-dialog-divider
+  margin-top: 10px !important
+  margin-bottom: 5px !important
+</style>
+
+<template>
+    <v-dialog
+    width="1000" persistent
+    :close-on-content-click="false"
+    v-model="showGeneAssociationDialog"
+    >
+
+      <v-card class="full-width">
+        <div class="container">
+          <v-btn text @click="onCancel" class="close-button" color="white">
+            <v-icon>close</v-icon>
+          </v-btn>
+          <v-card-title class="headline" style="padding-top: 10px;">Gene Associations in {{ selectedGene }}</v-card-title>
+        </div>
+        <v-divider id="gene-associations-dialog-divider"></v-divider>
+        <v-card-text style="padding-bottom: 0px">
+          <div class="container">
+            <div class="row">
+              <div class="col-md-4">
+                <table class="table">
+                  <thead>
+                    <tr> <strong>GTR</strong></tr>
+                  </thead>
+                  <tbody v-if="gtrHits.length">
+                    <tr v-for="(term, i) in gtrHits" :key="i">
+                      <td>
+                        <v-chip color="white" class="high_gene_rank mr-1">
+                          #{{ term.geneRanks[0].rank}}
+                        </v-chip> 
+                        {{ term.searchTerm | to-firstCharacterUppercase }}
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+                <div v-if="gtrHits.length<1">
+                  <span><i>Not associated with selected GTR conditions...</i></span>
+                </div>
+
+              </div>
+              <div class="col-md-4">
+                <table class="table">
+                  <thead>
+                    <tr> <strong>Phenolyzer</strong></tr>
+                  </thead>
+                  <tbody v-if="phenolyzerHits.length">
+                    <tr v-for="(term, i) in phenolyzerHits" :key="i">
+                      <td>
+                        <v-chip color="white" class="high_gene_rank mr-1">
+                          #{{ term.geneRanks[0].rank}}
+                        </v-chip> 
+                        {{ term.searchTerm | to-firstCharacterUppercase }}
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+                <div v-if="phenolyzerHits.length<1">
+                  <span><i>Not associated with selected phenotypes...</i></span>
+                </div>
+              </div>
+              <div class="col-md-4">
+                <table class="table">
+                  <thead>
+                    <tr> <strong>HPO</strong></tr>
+                  </thead>
+                  <tbody v-if="hpoHits.length">
+                    <tr v-for="(term, i) in hpoHits" :key="i">
+                      <td>{{ term.geneRanks[0].hpoPhenotype }} <i> ({{ term.searchTerm | to-firstCharacterUppercase }})</i></td>
+                    </tr>
+                  </tbody>
+                </table>
+                <div v-if="hpoHits.length<1">
+                  <span><i>Not associated with selected HPO terms...</i></span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="white" tile @click="onCancel">
+            Cancel
+          </v-btn>
+        </v-card-actions>
+
+      </v-card>
+    </v-dialog>
+</template>
+
+<script>
+
+
+export default {
+  name: 'gene-associations-dialog',
+  components: {
+  },
+  props: {
+    sourceNotes: null,
+    sourceIndex: null,
+    showDialog: null,
+    genePhenotypeHits: null,
+    selectedGene: null
+  },
+  data () {
+    return {
+      showGeneAssociationDialog: true,
+      notes: null, 
+      gtrHits: [], 
+      phenolyzerHits: [], 
+      hpoHits: [], 
+    }
+  },
+  watch: {
+  },
+  computed: {
+  },
+  methods: {
+    onApply: function() {
+      if (this.sourceNotes == '') {
+        this.$emit("add-variant-note", this.notes);
+      } else {
+        this.$emit("edit-variant-note", this.sourceIndex, this.notes)
+      }
+      this.showGeneAssociationDialog = false;
+    },
+    onCancel: function() {
+      this.showGeneAssociationDialog = false;
+      this.$emit("close-gene-association-dialog", this.showGeneAssociationDialog)
+    }, 
+    arrangeData: function() {
+      this.genePhenotypeHits.map(geneHit => {
+        if(geneHit.geneRanks[0].source === "GTR"){
+          this.gtrHits.push(geneHit)
+        }
+        else if(geneHit.geneRanks[0].source === "Phen."){
+          this.phenolyzerHits.push(geneHit)
+        }
+        else if(geneHit.geneRanks[0].source === "HPO"){
+          this.hpoHits.push(geneHit)
+        }
+      })
+    }
+  },
+  created: function() {
+  },
+  mounted: function() {
+    this.arrangeData();
+  },
+  updated: function() {
+  },
+  watch: {
+    showGeneAssociationDialog: function() {
+      let self = this;
+      if (self.showGeneAssociationDialog) {
+        self.notes = self.sourceNotes;
+      }
+    },
+    sourceNotes: function() {
+      this.notes = this.sourceNotes;
+    },
+    showDialog: function() {
+      this.showGeneAssociationDialog = this.showDialog
+    }, 
+
+  }
+}
+</script>

--- a/src/components/viz/findings/VariantInspectCard.vue
+++ b/src/components/viz/findings/VariantInspectCard.vue
@@ -125,10 +125,10 @@
                   <v-chip  color="white" v-else class="high">
                     <span v-if="geneRank.source"> {{ geneRank.source }}</span>
                   </v-chip>
-                  <span v-if="geneHit.searchTerm && geneRank.source!=='HPO'" class="pheno-search-term">
+                  <span v-if="geneHit.searchTerm && geneRank.source!=='HPO'" class="pheno-search-term_clin">
                     {{ geneHit.searchTerm | to-firstCharacterUppercase }}
                   </span>
-                  <span v-else-if="geneRank.source==='HPO' && geneRank.hpoPhenotype" class="pheno-search-term">
+                  <span v-else-if="geneRank.source==='HPO' && geneRank.hpoPhenotype" class="pheno-search-term_clin">
                     {{ geneRank.hpoPhenotype | to-firstCharacterUppercase }}
                   </span>
                 </div>
@@ -1203,7 +1203,7 @@ export default {
         &.last
           margin-bottom: 0px
 
-      .pheno-search-term
+      .pheno-search-term_clin
         max-width: 100px
         display: inline-block
         vertical-align: top

--- a/src/components/viz/findings/VariantInspectCard.vue
+++ b/src/components/viz/findings/VariantInspectCard.vue
@@ -118,11 +118,11 @@
             <div v-for="(geneHit, index) in genePhenotypeRankings.slice(0,3)" :key="geneHit.key" class="variant-row" style="flex-flow:column">
               <div v-for="geneRank in geneHit.geneRanks" :key="geneRank.rank">
                 <div>
-                  <v-chip v-if="geneRank.rank" class="high">
+                  <v-chip  color="white" v-if="geneRank.rank" class="high">
                     <span class="mr-1">#{{ geneRank.rank  }}</span>
                     <span v-if="geneRank.source">{{  geneRank.source }}</span>
                   </v-chip>
-                  <v-chip v-else class="high">
+                  <v-chip  color="white" v-else class="high">
                     <span v-if="geneRank.source"> {{ geneRank.source }}</span>
                   </v-chip>
                   <span v-if="geneHit.searchTerm && geneRank.source!=='HPO'" class="pheno-search-term">
@@ -139,6 +139,7 @@
             <v-btn id="show-more-gene-association-button"
               text small color="primary"
               slot="activator"
+              style="float:right"
               v-tooltip.bottom-center="`Show all associations for this variant`"
               @click="showMoreGeneAssociationsDialog=true">
                 <v-icon>zoom_out_map</v-icon>Show more
@@ -153,33 +154,6 @@
               @close-gene-association-dialog="onCloseGeneAssociationDialog($event)">
             </gene-associations-dialog>
           </div>
-          <!-- <div v-if="genePhenotypeRankings" v-for="geneHit in genePhenotypeRankings" :key="geneHit.key" class="variant-row" style="flex-flow:column">
-            <div v-for="geneRank in geneHit.geneRanks" :key="geneRank.rank">
-              <div>
-                <v-chip class="high">#{{ geneRank.rank }}</v-chip>
-                <span v-if="geneRank.source" class="pheno-source">{{ geneRank.source }}</span>
-                <span v-if="geneHit.searchTerm" class="pheno-search-term">{{ geneHit.searchTerm }}</span>
-              </div>
-              
-              <div>
-                  <v-chip v-if="geneRank.rank" class="high">
-                    <span class="mr-1">#{{ geneRank.rank  }}</span>
-                    <span v-if="geneRank.source">{{  geneRank.source }}</span>
-                  </v-chip>
-                  <v-chip v-else class="high">
-                    <span v-if="geneRank.source"> {{ geneRank.source }}</span>
-                  </v-chip>
-                  <span v-if="geneHit.searchTerm && geneRank.source!=='HPO'" class="pheno-search-term">
-                    {{ geneHit.searchTerm  }}
-                  </span>
-                  <span v-else-if="geneRank.source==='HPO' && geneRank.hpoPhenotype" class="pheno-search-term">
-                    {{ geneRank.hpoPhenotype  }}
-                  </span>
-                </div>
-                
-                
-            </div>
-          </div> -->
       </div>      
       <div class="variant-inspect-column" v-if="selectedVariant && info">
           <div class="variant-column-header">
@@ -1230,10 +1204,11 @@ export default {
           margin-bottom: 0px
 
       .pheno-search-term
-        max-width: 90px
+        max-width: 100px
         display: inline-block
         vertical-align: top
         line-height: 14px
+        padding-top: 5px
 
       #qual-track
         margin-top: 0px

--- a/src/components/viz/findings/VariantInspectCard.vue
+++ b/src/components/viz/findings/VariantInspectCard.vue
@@ -114,15 +114,72 @@
             Gene Associations
             <v-divider></v-divider>
           </div>
-          <div v-if="genePhenotypeRankings" v-for="geneHit in genePhenotypeRankings" :key="geneHit.key" class="variant-row" style="flex-flow:column">
+          <div v-if="genePhenotypeRankings && genePhenotypeRankings!==null && genePhenotypeRankings.length" >
+            <div v-for="(geneHit, index) in genePhenotypeRankings.slice(0,3)" :key="geneHit.key" class="variant-row" style="flex-flow:column">
+              <div v-for="geneRank in geneHit.geneRanks" :key="geneRank.rank">
+                <div>
+                  <v-chip v-if="geneRank.rank" class="high">
+                    <span class="mr-1">#{{ geneRank.rank  }}</span>
+                    <span v-if="geneRank.source">{{  geneRank.source }}</span>
+                  </v-chip>
+                  <v-chip v-else class="high">
+                    <span v-if="geneRank.source"> {{ geneRank.source }}</span>
+                  </v-chip>
+                  <span v-if="geneHit.searchTerm && geneRank.source!=='HPO'" class="pheno-search-term">
+                    {{ geneHit.searchTerm | to-firstCharacterUppercase }}
+                  </span>
+                  <span v-else-if="geneRank.source==='HPO' && geneRank.hpoPhenotype" class="pheno-search-term">
+                    {{ geneRank.hpoPhenotype | to-firstCharacterUppercase }}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div v-if="genePhenotypeRankings!==null && genePhenotypeRankings.length>=4">
+            <v-btn id="show-more-gene-association-button"
+              text small color="primary"
+              slot="activator"
+              v-tooltip.bottom-center="`Show all associations for this variant`"
+              @click="showMoreGeneAssociationsDialog=true">
+                <v-icon>zoom_out_map</v-icon>Show more
+            </v-btn>
+          </div>
+          <div>
+            <gene-associations-dialog
+              v-if="showMoreGeneAssociationsDialog"
+              :showDialog="showMoreGeneAssociationsDialog"
+              :genePhenotypeHits="genePhenotypeRankings"
+              :selectedGene="selectedGene.gene_name"
+              @close-gene-association-dialog="onCloseGeneAssociationDialog($event)">
+            </gene-associations-dialog>
+          </div>
+          <!-- <div v-if="genePhenotypeRankings" v-for="geneHit in genePhenotypeRankings" :key="geneHit.key" class="variant-row" style="flex-flow:column">
             <div v-for="geneRank in geneHit.geneRanks" :key="geneRank.rank">
               <div>
                 <v-chip class="high">#{{ geneRank.rank }}</v-chip>
                 <span v-if="geneRank.source" class="pheno-source">{{ geneRank.source }}</span>
                 <span v-if="geneHit.searchTerm" class="pheno-search-term">{{ geneHit.searchTerm }}</span>
               </div>
+              
+              <div>
+                  <v-chip v-if="geneRank.rank" class="high">
+                    <span class="mr-1">#{{ geneRank.rank  }}</span>
+                    <span v-if="geneRank.source">{{  geneRank.source }}</span>
+                  </v-chip>
+                  <v-chip v-else class="high">
+                    <span v-if="geneRank.source"> {{ geneRank.source }}</span>
+                  </v-chip>
+                  <span v-if="geneHit.searchTerm && geneRank.source!=='HPO'" class="pheno-search-term">
+                    {{ geneHit.searchTerm  }}
+                  </span>
+                  <span v-else-if="geneRank.source==='HPO' && geneRank.hpoPhenotype" class="pheno-search-term">
+                    {{ geneRank.hpoPhenotype  }}
+                  </span>
+                </div>
+                
+                
             </div>
-          </div>
+          </div> -->
       </div>      
       <div class="variant-inspect-column" v-if="selectedVariant && info">
           <div class="variant-column-header">
@@ -307,7 +364,7 @@ import GeneViz                  from "../../viz/findings/GeneViz.vue"
 import PedigreeGenotypeViz      from "../../viz/findings/PedigreeGenotypeViz.vue"
 import ConservationScoresViz    from "../../viz/findings/ConservationScoresViz.vue"
 import MultialignSeqViz         from "../../viz/findings/MultialignSeqViz.vue"
-
+import GeneAssociationsDialog   from "./GeneAssociationsDialog.vue"
 
 import BarChartD3               from '../../../d3/findings/BarChart.d3.js'
 import MultiAlignD3             from '../../../d3/findings/MultiAlign.d3.js'
@@ -331,7 +388,8 @@ export default {
     ToggleButton,
     ConservationScoresViz,
     MultialignSeqViz,
-    VariantInterpretationBadge
+    VariantInterpretationBadge,
+    GeneAssociationsDialog
   },
   props: {
     selectedVariant: null,
@@ -399,7 +457,8 @@ export default {
       ],
 
       // TODO - Need way to get coverage thresholds
-      geneCoverageMin: 10
+      geneCoverageMin: 10,
+      showMoreGeneAssociationsDialog: false,
 
 
 
@@ -876,6 +935,9 @@ export default {
     },
     gotoStep: function(stepIndex){
       bus.$emit('navigate-to-step',stepIndex); 
+    },
+    onCloseGeneAssociationDialog: function(data){
+      this.showMoreGeneAssociationsDialog = false;
     }
   },
 


### PR DESCRIPTION
Matches the style and functionality of the "Genes Association" column in the Findings page to the one in "review variants". 

Refer to the issue to see the broken style: #203 

To test: 
Select few terms from "select phenotypes": 
Eg: Hammertoe, Peripheral demyelination, Peripheral neuropathy, Charcot marie tooth disease

Add interpretation to the variant that has gene associations (PRX) 

Go to findings page, the gene association column should look as follows: 



<img width="252" alt="Screen Shot 2020-05-06 at 3 36 25 PM" src="https://user-images.githubusercontent.com/16284713/81235768-941a7780-8fb0-11ea-814d-5c9eba3950d3.png">


<img width="1048" alt="Screen Shot 2020-05-06 at 3 36 33 PM" src="https://user-images.githubusercontent.com/16284713/81235773-954ba480-8fb0-11ea-9990-411eec2ab9e6.png">
