### PR TITLE
Vcf variants input

### DIFF
--- a/src/components/pages/LandingPage.vue
+++ b/src/components/pages/LandingPage.vue
@@ -579,6 +579,8 @@
               <p>
                 Users can enter a list of genes or variants into clin.iobio. 
                 These are the genes and/or variants that will be reviewed in the clinical workflow steps of the app.
+                <br>
+                Variants can be imported from a .CSV file (<a href="https://drive.google.com/file/d/1JYTbDnMvQ3Nq6UbbUzYhda0CZj1h5Q4m/view" target="_blank">example</a>) or from a <a href="https://gene.iobio.io/" target="_blank"> gene.iobio </a> variants (.VCF) file.
               </p>
               <v-textarea
                 auto-grow

--- a/src/components/pages/LandingPage.vue
+++ b/src/components/pages/LandingPage.vue
@@ -295,6 +295,8 @@
                   <p style="text-align: justify">
                     Users can enter a list of genes or variants into clin.iobio. 
                     These are the genes and/or variants that will be reviewed in the clinical workflow steps of the app.
+                    <br>
+                    Variants can be imported from a .CSV file (<a href="https://drive.google.com/file/d/1JYTbDnMvQ3Nq6UbbUzYhda0CZj1h5Q4m/view" target="_blank">example</a>) or from a <a href="https://gene.iobio.io/" target="_blank"> gene.iobio </a> variants (.VCF) file.
                   </p>
 
                     <v-textarea

--- a/src/components/partials/ImportVariants.vue
+++ b/src/components/partials/ImportVariants.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
     <v-file-input 
-      accept=".csv" 
       label="  Import variants (.csv)" 
       v-model="variantsData" 
       @change="loadVariants"
@@ -40,14 +39,19 @@ import VariantImporter from '../../models/VariantImporter'
         if(this.variantsData){
           reader.readAsText(this.variantsData);
           reader.onload = () => {
-            
-            if(this.validateCsvImport(reader.result.trim())) {
-              this.importRecords = VariantImporter.parseRecordsCSV(reader.result);
-              this.$emit("load-variants", this.importRecords);
+            if(ev.type === "text/csv"){ //Checks if file format is csv
+              if(this.validateCsvImport(reader.result.trim())) {
+                this.importRecords = VariantImporter.parseRecordsCSV(reader.result);
+                console.log("this.importRecords", this.importRecords);
+                this.$emit("load-variants", this.importRecords);
+              }
+              else {
+                this.$emit("imported-variants-validation-errors");
+                this.variantsData = null;
+              }
             }
             else {
-              this.$emit("imported-variants-validation-errors");
-              this.variantsData = null;
+              this.parseVCFfile(reader.result.trim())
             }
           }
         }
@@ -73,6 +77,68 @@ import VariantImporter from '../../models/VariantImporter'
           }
         }
         return bool;
+      },
+      parseVCFfile(data){
+        let lines = data.split('\n');
+        var idx = 0;
+        for(let i=0; i<lines.length; i++){
+          if(lines[i].includes('#CHROM')){
+            idx = i; 
+            break;
+          }
+          else {
+            // TODO: does not include chromose position, so invalid VCF and show error msg
+          }
+        }
+        
+        var importRecords = [];
+        let variants_data = lines.slice(idx+1); 
+        for (var i = 0; i < variants_data.length; i++) {
+          let splitLine = variants_data[i].split('\t');
+          console.log("splitLine", splitLine);
+          var importRec = {};
+          importRec.chrom = splitLine[0];
+          // importRec.start = splitLine[1];
+          // importRec.end = splitLine[1];
+          importRec.ref = splitLine[3];
+          importRec.alt = splitLine[4];
+          // importRec.filtersPassed = "notCategorized";
+          importRec.variantSet = "notCategorized";
+          importRec.isImported = true;
+          
+          var info_data = splitLine[7].split("IOBIO=")[1].split("|");
+          console.log("info_data", info_data);
+          
+          var start = info_data[0].replace("start#", "").trim();
+          start !== '.' ? importRec.start = start : importRec.start = splitLine[1];
+
+          var end = info_data[1].replace("end#", "").trim();
+          end !== '.' ? importRec.end = end : importRec.end = splitLine[1];
+
+          var geneName = info_data[2].replace("geneName#", "").trim();
+          importRec.gene = geneName;
+
+          var filtersPassed = info_data[5].replace("filtersPassed#", "").trim();
+          filtersPassed !== '.' ? importRec.filtersPassed = filtersPassed : importRec.filtersPassed = '';
+
+          var consequence = info_data[11].replace("consequence#", "").trim();
+          consequence !== '.' ? importRec.consequence = consequence : importRec.consequence = '';
+          
+          var inheritance = info_data[15].replace("inheritance#", "").trim();
+          inheritance !== '.' ? importRec.inheritance = inheritance : importRec.inheritance = null;
+
+          
+          var afgnomAD = info_data[14].replace("afgnomAD#", "").trim();
+          afgnomAD !== '.' ? importRec.afgnomAD = afgnomAD : importRec.afgnomAD = '';
+
+          var impact = info_data[8].replace("impact#", "").trim();
+          impact !== '.' ? importRec.highestImpact = impact : importRec.highestImpact = '';
+
+          importRecords.push(importRec);
+
+        }
+        
+        this.$emit("load-variants", importRecords);
       }
     }, 
 

--- a/src/components/partials/ImportVariants.vue
+++ b/src/components/partials/ImportVariants.vue
@@ -1,7 +1,8 @@
 <template>
   <div>
     <v-file-input 
-      label="  Import variants (.csv)" 
+      label="  Import variants (.csv, .vcf)"
+      accept=".csv, .vcf"
       v-model="variantsData" 
       @change="loadVariants"
       show-size counter
@@ -42,7 +43,6 @@ import VariantImporter from '../../models/VariantImporter'
             if(ev.type === "text/csv"){ //Checks if file format is csv
               if(this.validateCsvImport(reader.result.trim())) {
                 this.importRecords = VariantImporter.parseRecordsCSV(reader.result);
-                console.log("this.importRecords", this.importRecords);
                 this.$emit("load-variants", this.importRecords);
               }
               else {
@@ -81,64 +81,76 @@ import VariantImporter from '../../models/VariantImporter'
       parseVCFfile(data){
         let lines = data.split('\n');
         var idx = 0;
+        var validVcfFile = true;
         for(let i=0; i<lines.length; i++){
           if(lines[i].includes('#CHROM')){
             idx = i; 
             break;
           }
           else {
-            // TODO: does not include chromose position, so invalid VCF and show error msg
+            //Does not include chromose position, so invalid VCF and show error msg
+            if(i === lines.length-1){
+              validVcfFile = false;
+            }
           }
         }
         
-        var importRecords = [];
-        let variants_data = lines.slice(idx+1); 
-        for (var i = 0; i < variants_data.length; i++) {
-          let splitLine = variants_data[i].split('\t');
-          console.log("splitLine", splitLine);
-          var importRec = {};
-          importRec.chrom = splitLine[0];
-          // importRec.start = splitLine[1];
-          // importRec.end = splitLine[1];
-          importRec.ref = splitLine[3];
-          importRec.alt = splitLine[4];
-          // importRec.filtersPassed = "notCategorized";
-          importRec.variantSet = "notCategorized";
-          importRec.isImported = true;
+        if(validVcfFile){
+          var importRecords = [];
+          let variants_data = lines.slice(idx+1); 
+          for (var i = 0; i < variants_data.length; i++) {
+            let splitLine = variants_data[i].split('\t');
+            if(splitLine[7].includes("IOBIO")){
+              var importRec = {};
+              importRec.chrom = splitLine[0];
+              importRec.ref = splitLine[3];
+              importRec.alt = splitLine[4];
+              importRec.variantSet = "notCategorized";
+              importRec.isImported = true;
+              
+              var info_data = splitLine[7].split("IOBIO=")[1].split("|");
+              
+              var start = info_data[0].replace("start#", "").trim();
+              start !== '.' ? importRec.start = start : importRec.start = splitLine[1];
+
+              var end = info_data[1].replace("end#", "").trim();
+              end !== '.' ? importRec.end = end : importRec.end = splitLine[1];
+
+              var geneName = info_data[2].replace("geneName#", "").trim();
+              importRec.gene = geneName;
+
+              var filtersPassed = info_data[5].replace("filtersPassed#", "").trim();
+              filtersPassed !== '.' ? importRec.filtersPassed = filtersPassed : importRec.filtersPassed = '';
+
+              var consequence = info_data[11].replace("consequence#", "").trim();
+              consequence !== '.' ? importRec.consequence = consequence : importRec.consequence = '';
+              
+              var inheritance = info_data[15].replace("inheritance#", "").trim();
+              inheritance !== '.' ? importRec.inheritance = inheritance : importRec.inheritance = null;
+
+              var afgnomAD = info_data[14].replace("afgnomAD#", "").trim();
+              afgnomAD !== '.' ? importRec.afgnomAD = afgnomAD : importRec.afgnomAD = '';
+
+              var impact = info_data[8].replace("impact#", "").trim();
+              impact !== '.' ? importRec.highestImpact = impact : importRec.highestImpact = '';
+
+              importRecords.push(importRec);
+            }
+            else {
+              //Not a gene.iobio exported vcf file
+              this.$emit("imported-variants-validation-errors");
+              this.variantsData = null;
+            }
+          }
           
-          var info_data = splitLine[7].split("IOBIO=")[1].split("|");
-          console.log("info_data", info_data);
-          
-          var start = info_data[0].replace("start#", "").trim();
-          start !== '.' ? importRec.start = start : importRec.start = splitLine[1];
-
-          var end = info_data[1].replace("end#", "").trim();
-          end !== '.' ? importRec.end = end : importRec.end = splitLine[1];
-
-          var geneName = info_data[2].replace("geneName#", "").trim();
-          importRec.gene = geneName;
-
-          var filtersPassed = info_data[5].replace("filtersPassed#", "").trim();
-          filtersPassed !== '.' ? importRec.filtersPassed = filtersPassed : importRec.filtersPassed = '';
-
-          var consequence = info_data[11].replace("consequence#", "").trim();
-          consequence !== '.' ? importRec.consequence = consequence : importRec.consequence = '';
-          
-          var inheritance = info_data[15].replace("inheritance#", "").trim();
-          inheritance !== '.' ? importRec.inheritance = inheritance : importRec.inheritance = null;
-
-          
-          var afgnomAD = info_data[14].replace("afgnomAD#", "").trim();
-          afgnomAD !== '.' ? importRec.afgnomAD = afgnomAD : importRec.afgnomAD = '';
-
-          var impact = info_data[8].replace("impact#", "").trim();
-          impact !== '.' ? importRec.highestImpact = impact : importRec.highestImpact = '';
-
-          importRecords.push(importRec);
-
+          this.$emit("load-variants", importRecords);
+        }
+        else {
+          this.$emit("imported-variants-validation-errors");
+          this.variantsData = null;
         }
         
-        this.$emit("load-variants", importRecords);
+
       }
     }, 
 


### PR DESCRIPTION
This PR will allow importing variants that are exported from gene.iobio as VCF file. 

To test: 

- Pull gene.iobio PR: https://github.com/iobio/gene.iobio.vue/pull/649
- Run gene.iobio with demo data and export the variant in VCF format.
- Launch clin 
- Click "Upload configuration file" 
- Upload the configuration file 
- Upload the downloaded VCF file 
- Load 

The review-variants step should load the imported variants. 